### PR TITLE
Use 'stream.split' + move to trait for listeners

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::parser::{parse_msg, Msg, PrivMsg, User};
 use futures_util::future::BoxFuture;
 use futures_util::stream::SplitSink;
-use futures_util::{sink::SinkExt};
+use futures_util::sink::SinkExt;
 use futures_util::StreamExt;
 use tokio::sync::Mutex;
 use websocket_lite::{AsyncClient, AsyncNetworkStream, Message, Opcode, Result};
@@ -11,14 +11,18 @@ use websocket_lite::{AsyncClient, AsyncNetworkStream, Message, Opcode, Result};
 pub trait PrivMessageListenerT {
     fn on_priv_msg<'sel, 'msg, 'body, 'sender, 'output>(&'sel self, msg: &'msg PrivMsg<'body>, sender: &'sender mut MySender) -> BoxFuture<'output, ()>
         where
-            // 'p > 's
+            // 'msg >= 'sel
             'msg: 'sel,
-            // 'b > 's
+            // 'body >= 'sel
             'body: 'sel,
-            // 'sender > 's
+            // 'sender >= 'sel
             'sender: 'sel,
-            // 'p > 's
-            'sender: 'output
+            // 'sender >= 'output
+            'sender: 'output,
+            // 'msg >= 'output
+            'msg: 'output,
+            // 'body >= 'output
+            'body: 'output
         ;
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,15 +11,17 @@ mod parser;
 struct Reply {}
 
 impl PrivMessageListenerT for Reply {
-    fn on_priv_msg<'s, 'p, 'b, 'sender, 'output>(&'s self, msg: &'p PrivMsg<'b>, sender: &'sender mut MySender) -> BoxFuture<'output, ()>
+    fn on_priv_msg<'sel, 'msg, 'body, 'sender, 'output>(&'sel self, msg: &'msg PrivMsg<'body>, sender: &'sender mut MySender) -> BoxFuture<'output, ()>
     where
-            'p: 's,
-            'b: 's,
-            'sender: 's,
-            'sender: 'output
+            'msg: 'sel,
+            'body: 'sel,
+            'sender: 'sel,
+            'sender: 'output,
+            'msg: 'output,
+            'body: 'output
     {
         Box::pin(async move {
-            sender.send_text("Hello!").await.unwrap();
+            sender.send_text(format!("Hello {}! How are you?", msg.user.nick).as_str()).await.unwrap();
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,35 @@
+use client::PrivMessageListenerT;
+use futures_util::future::BoxFuture;
 use parser::PrivMsg;
 use websocket_lite::Result;
 
-use crate::client::Client;
+use crate::client::{Client, MySender};
 
 mod client;
 mod parser;
+
+struct Reply {}
+
+impl PrivMessageListenerT for Reply {
+    fn on_priv_msg<'s, 'p, 'b, 'sender, 'output>(&'s self, msg: &'p PrivMsg<'b>, sender: &'sender mut MySender) -> BoxFuture<'output, ()>
+    where
+            'p: 's,
+            'b: 's,
+            'sender: 's,
+            'sender: 'output
+    {
+        Box::pin(async move {
+            sender.send_text("Hello!").await.unwrap();
+        })
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let twitch_token = std::env::var("TWITCH_TOKEN").expect("Missing TWITCH_TOKEN");
     let mut client = Client::new("loige".to_string(), "loigebot".to_string());
 
-    client.add_priv_msg_listener(Box::new(|m: PrivMsg<'_>, connected_client| {
-        // let runtime = tokio::runtime::Runtime::new().unwrap();
-        // println!("PRIV MSG: {:?}", m);
-        // TODO: the code below does not work because we end up borrrowing mutably more than once! We probably need a Mutex!
-        return Box::new(async {
-            connected_client
-                .send_msg(format!("Hello {}! How are you?", m.user.nick).as_str())
-                .await;
-        });
-    }));
+    client.add_priv_msg_listener(Box::new(Reply {}));
 
     let client = client.connect(twitch_token).await?;
     client.run().await?;


### PR DESCRIPTION
Major changes:
- `run` method consumes `self`
- used structure destructuring to separate `client` from `stream`
- used `stream.split()` to split the read part from the write one
- create `MySender` to hold the writing side of the stream + implement some practical methods
- move from taking a function as a listener to the trait (it simplifies the definition)
- explicit lifetimes for trait

Reasons:
- the reading side has to be split from the writing; otherwise, you cannot read & write in the same loop: leveraging the same variable, the loop keeps a mutable reference active, and it prevents you from sending messages (that takes a mutable reference too)
- manage `Box<dyn PrivMessageListenerT>` is easier than function pointers

Improvements:
- implement the trait `PrivMessageListenerT` for `FnMut` (I tried, but I failed 😢 )
- avoid Arc<Mutex<...>>: it could be avoided using channel. You can take a thread that consumes the channel and send messages. In the loop, you can send the message to the channel. NB: this changes the guarantee of delivery / handling the socket error but improves the performance a lot because there are no Mutex locks.